### PR TITLE
fixes related to this morning's bad changelog

### DIFF
--- a/lib/Changelog.pm
+++ b/lib/Changelog.pm
@@ -21,7 +21,11 @@ sub formatted_log_message {
         grep { /^CHANGELOG/ }
         split(/\n\n/, $log->body);
     chomp @paragraphs;
-    return _signed_changelog($log->author_name, $log->commit, @paragraphs);
+    @paragraphs =
+        map { _signed_changelog($log->author_name, $log->commit, $_) }
+        @paragraphs;
+
+    return join('', @paragraphs);
 }
 
 sub _signed_changelog {

--- a/t/Changelog.t
+++ b/t/Changelog.t
@@ -24,6 +24,8 @@ my @cases = (
      qr(^This is seven changelog\.)],
     [qq(Remove ModelGroups from AnPs\n\nCHANGELOG: As of this commit, Analysis Projects no longer have\nan associated Model Group. The canonical source of Analysis Project),
      qr(^As of this commit, Analysis Projects no longer have\nan associated Model Group. The canonical source of Analysis Project)],
+    [qq(SUBJECT\n\nBODY1\n\nCHANGELOG: LINE ONE\nLINE TWO\n\nSOME OTHER PARAGRAPH\n\nCHANGELOG: LINE ONE\nLINE TWO\n),
+     qr(^LINE ONE\nLINE TWO\n--[^\n]*\n\nLINE ONE\nLINE TWO\n--[^\n]*\n)],
 );
 plan tests => scalar(@cases);
 


### PR DESCRIPTION
The changelog this morning was truncated:

> As of this commit, Analysis Projects no longer have
> -- Adam Coffman (317ecfe)

Signing each changelog paragraph may or may not be desired.  The syntax for
writing changelogs was all very loose and not really well defined.
