### PR TITLE
update template to cdf1e54

### DIFF
--- a/bin/db-migration.sh
+++ b/bin/db-migration.sh
@@ -3,7 +3,7 @@ TESTDBSERVER_DB_USER="genome"
 TESTDBSERVER_DB_PASS="mypassword"
 export TESTDBSERVER_URL="https://apipe-test-db.gsc.wustl.edu"
 
-eval "$(test-db database create --bash --owner $TESTDBSERVER_DB_USER --based-on snapshot-3549)"
+eval "$(test-db database create --bash --owner $TESTDBSERVER_DB_USER --based-on cdf1e54)"
 if test -z "$TESTDBSERVER_DB_NAME"
 then
     echo "Failed to create test database."


### PR DESCRIPTION
I created a new template, `cdf1e54`, corresponding to the hash in `genome.git` 
which builds on `snapshot-3549` but adds the BWAMEM aligner index for
`Genome/InstrumentData/AlignmentResult/Bwamem.t`.  This was added by doing:

```
$ test-db database create --bash --owner $TESTDBSERVER_DB_USER --based-on
snapshot-3549
$ export
GENOME_TEST_FILLDB="dbi:Pg:dbname=BD529224866311E4849B860495573682;host=apipe-test-db.gsc.wustl.edu;user=genome;password=mypassword"
$ genome-re.pl my $reference_model =
Genome::Model::ImportedReferenceSequence->get(name => 'TEST-human'); my
$reference_build = $reference_model->build_by_version('1'); my $alnidx =
Genome::Model::Build::ReferenceSequence::AlignerIndex->get_with_lock(aligner_name
=> "bwamem", reference_build_id => $reference_build->id, aligner_version =>
'0.7.10');
$ test-db tempalte create cdf1e54 BD529224866311E4849B860495573682
```
