### PR TITLE
fix URL due to rename of view

### DIFF
--- a/bin/update-submodule-to-jenkins-stable
+++ b/bin/update-submodule-to-jenkins-stable
@@ -49,7 +49,7 @@ sub update_submodule {
 
 sub last_stable_revision {
     my $project = shift || die;
-    my $url_f = 'https://apipe-ci.gsc.wustl.edu/view/Genome%%20Submodules/job/%s/lastStableBuild/api/xml?xpath=/freeStyleBuild/action/lastBuiltRevision/SHA1';
+    my $url_f = 'https://apipe-ci.gsc.wustl.edu/view/All/job/%s/lastStableBuild/api/xml?xpath=/freeStyleBuild/action/lastBuiltRevision/SHA1';
     my $url = sprintf($url_f, $project);
 
     my $ua = LWP::UserAgent->new(ssl_opts => { verify_hostname => 0 });


### PR DESCRIPTION
I renamed the "Genome Submodules" view to "Submodules" to reduce width. 
Update this URL to use the "All" view so that any future renames will not
affect this.