### PR TITLE
caller should use `genome-env` not this

### DIFF
--- a/bin/model-test
+++ b/bin/model-test
@@ -34,4 +34,4 @@ export GENOMECI_BASEDIR='/gsc/scripts/opt/genome'
 export PERL5LIB="$GENOMECI_BASEDIR/lib:$PERL5LIB"
 
 "$GENOMECI_BASEDIR"/bin/set-perl $PERL_VERSION
-genome-env "$GENOMECI_BASEDIR"/bin/model-test-multi
+"$GENOMECI_BASEDIR"/bin/model-test-multi


### PR DESCRIPTION
This is mostly in preparation for `genome-env-next` which is configurable so
calling it here would prevent the caller from configuring the environment.

When I deploy this I'll need to update four jobs on `apipe-ci` to call it with `genome-env`.