### PR TITLE
lengthen default timeout

### DIFF
--- a/bin/model-test-multi
+++ b/bin/model-test-multi
@@ -104,9 +104,8 @@ sub model {
 sub get_timeout {
     my %MODEL_TIMEOUTS = (
         'somatic-variation' => 36,
-        'clinseq-v1' => 12,
     );
-    my $DEFAULT_TIMEOUT = 6;
+    my $DEFAULT_TIMEOUT = 18;
     my $timeout_hours = $MODEL_TIMEOUTS{model_subname()} || $DEFAULT_TIMEOUT;
     my $timeout_seconds = $timeout_hours * 3600;
 


### PR DESCRIPTION
We will soon be using ephemeral databases with model tests which would not
currently support resuming a model-test so to counter that I am lengthening
the default timeout.