### PR TITLE
don't call `changelog` if the version hasn't changed

### DIFF
--- a/bin/promote
+++ b/bin/promote
@@ -216,7 +216,9 @@ sub create_changes_summary {
         system("touch $git_changelog_lock_file");
     }
 
-    run("$BIN_DIR/changelog $old_git_version $new_git_version > $snapshot_path/git-changelog");
+    if ($old_git_version ne $new_git_version) {
+        run("$BIN_DIR/changelog $old_git_version $new_git_version > $snapshot_path/git-changelog");
+    }
 
     # create CHANGE_SUMMARY
     unlink("$snapshot_path/CHANGE_SUMMARY");


### PR DESCRIPTION
`changelog` will fail if the versions are the same since there can be no 
changes so avoid calling it when the versions are the same.