### PR TITLE
Add cle test

### DIFF
--- a/bin/cle-test
+++ b/bin/cle-test
@@ -21,8 +21,88 @@ if (Genome::Sys->username eq 'apipe-tester' && !$ENV{MODEL_TEST_TO}) {
     $ENV{MODEL_TEST_TO} = Library::users_to_addresses(Users->cle);
 }
 
-my $cle_test = Genome::Site::TGI::CleTest->create();
-my @builds = $cle_test->get_builds();
+my $cmd0 = Genome::Config::AnalysisProject::Command::Create->create(
+    environment => "ad-hoc",
+    name => "CLE Test",
+    no_config => 1
+);
+my $analysis_project = $cmd0->execute;
+my $menu_item1 = Genome::Config::AnalysisMenu::Item->get("9ab6e28f832a428393b87b171d444401");
+my $menu_item2 = Genome::Config::AnalysisMenu::Item->get("3770b8510d5a459f9c0bb01fabf56337");
+my $discovery_tag = Genome::Config::Tag->get(name => 'discovery');
+my $followup_tag = Genome::Config::Tag->get(name => 'followup');
+my $germline_tag = Genome::Config::Tag->get(name => 'germline');
+my $cmd1 = Genome::Config::AnalysisProject::Command::AddMenuItem->create(
+    analysis_menu_items => $menu_item1,
+    tags => $discovery_tag,
+    analysis_project => $analysis_project,
+);
+$cmd1->execute;
+my $cmd2 = Genome::Config::AnalysisProject::Command::AddMenuItem->create(
+    analysis_menu_items => $menu_item1,
+    tags => $followup_tag,
+    analysis_project => $analysis_project,
+);
+$cmd2->execute;
+my $cmd3 = Genome::Config::AnalysisProject::Command::AddMenuItem->create(
+    analysis_menu_items => $menu_item2,
+    tags => $germline_tag,
+    analysis_project => $analysis_project,
+);
+$cmd3->execute;
+my $subject_mapping_file = Genome::Sys->create_temp_file_path;
+my $subject_mapping = <<'SUBJECT_MAPPINGS';
+H_KA-174556-1309237	H_KA-174556-1309246				followup
+H_KA-174556-1309245	H_KA-174556-1309246				discovery
+H_KA-174556-1309246					germline
+SUBJECT_MAPPINGS
+
+Genome::Sys->write_file($subject_mapping_file, $subject_mapping);
+my $cmd4 = Genome::Config::AnalysisProject::SubjectMapping::Command::Import::SomaticValidation->create(
+    analysis_project => $analysis_project,
+    file_path => $subject_mapping_file,
+);
+$cmd4->execute;
+
+my @instrument_data = qw(2893814999 2893815000 2893815001 2893815002 2893815003 2893815016 2893815018 2893815020 2893815023 2893815024 2893815447 2893815448 2893815449 2893815451 2893815484 2893815485 2893815489 2893815492);
+for my $id (@instrument_data) {
+    my $instrument_data = Genome::InstrumentData->get($id);
+    Genome::Config::AnalysisProject::InstrumentDataBridge->create(
+        analysis_project => $analysis_project,
+        instrument_data => $instrument_data,
+        status => 'new',
+    );
+}
+
+my $cmd5 = Genome::Config::AnalysisProject::Command::Release->create(
+    analysis_projects => [$analysis_project],
+);
+$cmd5->execute;
+
+my @instrument_data_objects = Genome::InstrumentData->get(id => \@instrument_data);
+my @pre_cqid_models = Genome::Model->get();
+my $pre_cqid_model_count = scalar @pre_cqid_models;
+my $cmd6 = Genome::Config::Command::ConfigureQueuedInstrumentData->create(
+    instrument_data => \@instrument_data_objects,
+);
+$cmd6->execute;
+my @post_cqid_models = Genome::Model->get();
+my $post_cqid_model_count = scalar @post_cqid_models;
+my $expected_number_of_models = 7;
+my $actual_number_of_models = $post_cqid_model_count - $pre_cqid_model_count;
+unless ($actual_number_of_models == $expected_number_of_models) {
+    fail(sprintf("We expected CQID to create %s models and it actually created %s\n",
+        $expected_number_of_models,
+        $actual_number_of_models));
+}
+
+my @models = Genome::Model->get(analysis_projects => [$analysis_project]);
+my $start_cmd = Genome::Model::Build::Command::Start->create(
+    models => \@models,
+);
+$start_cmd->execute;
+UR::Context->commit;
+my @builds = Genome::Model::Build->get(model_id => [map {$_->id} @models]);
 
 my $start_time = time;
 my @diff_cmds;
@@ -32,13 +112,30 @@ for my $build (@builds) {
     Library::wait_for_build($build, $start_time, $timeout);
     UR::Context->current->reload($build);
     Library::check_build_failure($build);
-    my $diff_cmd = $cle_test->diff_build($build);
+    my $diff_cmd = diff_build($build);
     if (defined $diff_cmd) {
         push @diff_cmds, $diff_cmd;
     }
 }
 
-my $process = $cle_test->get_process();
+my $discovery_subject = get_sample_from_subject_mapping($analysis_project, $discovery_tag);
+my $followup_subject = get_sample_from_subject_mapping($analysis_project, $followup_tag);
+my $germline_subject = get_sample_from_subject_mapping($analysis_project, $germline_tag);
+
+my @models_for_process = Genome::Model::SomaticValidation->get(analysis_projects => [$analysis_project],
+    region_of_interest_set_name => 'SeqCap EZ Human Exome v3.0 + AML RMG pooled probes + WO2830729 pooled probes + WO2840081 pooled probes');
+my @coverage_models_for_process = Genome::Model::SomaticValidation->get(analysis_projects => [$analysis_project],
+    tumor_sample => [$discovery_subject, $followup_subject]);
+my @germline_models = grep {$_->tumor_sample eq $germline_subject} @models_for_process;
+my $process_command = Genome::VariantReporting::Command::Wrappers::Trio->create(
+    models => \@models_for_process,
+    coverage_models => \@coverage_models_for_process,
+    tumor_sample => $discovery_subject,
+    followup_sample => $followup_subject,
+    normal_sample => $germline_subject,
+);
+my $process = $process_command->execute;
+UR::Context->commit;
 
 Library::wait_for_process($process, $timeout);
 
@@ -46,7 +143,7 @@ UR::Context->current->reload($process);
 
 Library::check_process_failure($process);
 
-my $process_diff_cmd = $cle_test->diff_process($process);
+my $process_diff_cmd = diff_process($process);
 if ($process_diff_cmd) {
     push @diff_cmds, $process_diff_cmd;
 }
@@ -55,6 +152,76 @@ if (@diff_cmds) {
     exit(255);
 }
 # functions
+sub get_sample_from_subject_mapping {
+    my ($anp, $tag) = @_;
+    my $mapping = Genome::Config::AnalysisProject::SubjectMapping->get(analysis_project => $anp,
+        tags => [$tag]);
+    my ($bridge) = $mapping->subject_bridges(label => 'tumor_sample');
+    return $bridge->subject;
+}
+
+sub diff_build {
+    my $build = shift;
+
+    printf("Starting diff (new build = %s)...\n", $build->id);
+
+    my @blessed_builds = Genome::Model::Build->get(id => [qw(
+    185d8bac3d7c4437b7ce9207dfadac7e
+    5f57f08a8fd84886b275f0b5571e9fd7
+    e02e8a5ccaad458d839de51eb47d8d2c
+    26e65adaa8034dd99ef92b27f61ad862
+    3243f261a8b64c089a5254291f7c2de3
+    f87701c292e843958d088e171a65a67a
+    301d5d51c96e41308d015008720f3962
+    )]);
+
+    my $matching_blessed_build;
+    for my $blessed_build (@blessed_builds) {
+        if ($build->tumor_sample eq $blessed_build->tumor_sample and
+                ((!defined($build->normal_sample) and !defined($blessed_build->normal_sample)) or
+                    ($build->normal_sample eq $blessed_build->normal_sample)) and
+            $build->target_region_set_name eq $blessed_build->target_region_set_name) {
+                $matching_blessed_build = $blessed_build;
+                last;
+            }
+    }
+    unless (defined $matching_blessed_build) {
+        fail(sprintf("No matching blessed build found for build %s\n", $build->id));
+    }
+
+    my $diff_cmd = Genome::Model::Build::Command::Diff->create(
+        new_build => $build,
+        blessed_build => $matching_blessed_build,
+    );
+    unless ($diff_cmd->execute) {
+        fail(sprintf("Diff command failed to execute for build %s!\n", $build->id));
+    }
+
+    if (Library::diff_cmd_has_diffs($diff_cmd)) {
+        return $diff_cmd;
+    }
+    return;
+}
+
+sub diff_process {
+    my $process = shift;
+
+    my $blessed_process = Genome::Process->get("2b2b3d8481284fcf8a1632d65ba58083");
+
+    printf("Starting diff (new process = %s)...\n", $process->id);
+    my $diff_cmd = Genome::Process::Command::Diff->create(
+        new_process => $process,
+        blessed_process => $blessed_process,
+    );
+    unless ($diff_cmd->execute) {
+        fail("Diff command failed to execute!\n");
+    }
+
+    if (Library::diff_cmd_has_diffs($diff_cmd)) {
+        return $diff_cmd;
+    }
+    return;
+}
 
 sub fail {
     Library::fail("cle test", @_);

--- a/bin/cle-test
+++ b/bin/cle-test
@@ -21,88 +21,8 @@ if (Genome::Sys->username eq 'apipe-tester' && !$ENV{MODEL_TEST_TO}) {
     $ENV{MODEL_TEST_TO} = Library::users_to_addresses(Users->cle);
 }
 
-my $cmd0 = Genome::Config::AnalysisProject::Command::Create->create(
-    environment => "ad-hoc",
-    name => "CLE Test",
-    no_config => 1
-);
-my $analysis_project = $cmd0->execute;
-my $menu_item1 = Genome::Config::AnalysisMenu::Item->get("9ab6e28f832a428393b87b171d444401");
-my $menu_item2 = Genome::Config::AnalysisMenu::Item->get("3770b8510d5a459f9c0bb01fabf56337");
-my $discovery_tag = Genome::Config::Tag->get(name => 'discovery');
-my $followup_tag = Genome::Config::Tag->get(name => 'followup');
-my $germline_tag = Genome::Config::Tag->get(name => 'germline');
-my $cmd1 = Genome::Config::AnalysisProject::Command::AddMenuItem->create(
-    analysis_menu_items => $menu_item1,
-    tags => $discovery_tag,
-    analysis_project => $analysis_project,
-);
-$cmd1->execute;
-my $cmd2 = Genome::Config::AnalysisProject::Command::AddMenuItem->create(
-    analysis_menu_items => $menu_item1,
-    tags => $followup_tag,
-    analysis_project => $analysis_project,
-);
-$cmd2->execute;
-my $cmd3 = Genome::Config::AnalysisProject::Command::AddMenuItem->create(
-    analysis_menu_items => $menu_item2,
-    tags => $germline_tag,
-    analysis_project => $analysis_project,
-);
-$cmd3->execute;
-my $subject_mapping_file = Genome::Sys->create_temp_file_path;
-my $subject_mapping = <<'SUBJECT_MAPPINGS';
-H_KA-174556-1309237	H_KA-174556-1309246				followup
-H_KA-174556-1309245	H_KA-174556-1309246				discovery
-H_KA-174556-1309246					germline
-SUBJECT_MAPPINGS
-
-Genome::Sys->write_file($subject_mapping_file, $subject_mapping);
-my $cmd4 = Genome::Config::AnalysisProject::SubjectMapping::Command::Import::SomaticValidation->create(
-    analysis_project => $analysis_project,
-    file_path => $subject_mapping_file,
-);
-$cmd4->execute;
-
-my @instrument_data = qw(2893814999 2893815000 2893815001 2893815002 2893815003 2893815016 2893815018 2893815020 2893815023 2893815024 2893815447 2893815448 2893815449 2893815451 2893815484 2893815485 2893815489 2893815492);
-for my $id (@instrument_data) {
-    my $instrument_data = Genome::InstrumentData->get($id);
-    Genome::Config::AnalysisProject::InstrumentDataBridge->create(
-        analysis_project => $analysis_project,
-        instrument_data => $instrument_data,
-        status => 'new',
-    );
-}
-
-my $cmd5 = Genome::Config::AnalysisProject::Command::Release->create(
-    analysis_projects => [$analysis_project],
-);
-$cmd5->execute;
-
-my @instrument_data_objects = Genome::InstrumentData->get(id => \@instrument_data);
-my @pre_cqid_models = Genome::Model->get();
-my $pre_cqid_model_count = scalar @pre_cqid_models;
-my $cmd6 = Genome::Config::Command::ConfigureQueuedInstrumentData->create(
-    instrument_data => \@instrument_data_objects,
-);
-$cmd6->execute;
-my @post_cqid_models = Genome::Model->get();
-my $post_cqid_model_count = scalar @post_cqid_models;
-my $expected_number_of_models = 7;
-my $actual_number_of_models = $post_cqid_model_count - $pre_cqid_model_count;
-unless ($actual_number_of_models == $expected_number_of_models) {
-    fail(sprintf("We expected CQID to create %s models and it actually created %s\n",
-        $expected_number_of_models,
-        $actual_number_of_models));
-}
-
-my @models = Genome::Model->get(analysis_projects => [$analysis_project]);
-my $start_cmd = Genome::Model::Build::Command::Start->create(
-    models => \@models,
-);
-$start_cmd->execute;
-UR::Context->commit;
-my @builds = Genome::Model::Build->get(model_id => [map {$_->id} @models]);
+my $cle_test = Genome::Site::TGI::CleTest->create();
+my @builds = $cle_test->get_builds();
 
 my $start_time = time;
 my @diff_cmds;
@@ -112,30 +32,13 @@ for my $build (@builds) {
     Library::wait_for_build($build, $start_time, $timeout);
     UR::Context->current->reload($build);
     Library::check_build_failure($build);
-    my $diff_cmd = diff_build($build);
+    my $diff_cmd = $cle_test->diff_build($build);
     if (defined $diff_cmd) {
         push @diff_cmds, $diff_cmd;
     }
 }
 
-my $discovery_subject = get_sample_from_subject_mapping($analysis_project, $discovery_tag);
-my $followup_subject = get_sample_from_subject_mapping($analysis_project, $followup_tag);
-my $germline_subject = get_sample_from_subject_mapping($analysis_project, $germline_tag);
-
-my @models_for_process = Genome::Model::SomaticValidation->get(analysis_projects => [$analysis_project],
-    region_of_interest_set_name => 'SeqCap EZ Human Exome v3.0 + AML RMG pooled probes + WO2830729 pooled probes + WO2840081 pooled probes');
-my @coverage_models_for_process = Genome::Model::SomaticValidation->get(analysis_projects => [$analysis_project],
-    tumor_sample => [$discovery_subject, $followup_subject]);
-my @germline_models = grep {$_->tumor_sample eq $germline_subject} @models_for_process;
-my $process_command = Genome::VariantReporting::Command::Wrappers::Trio->create(
-    models => \@models_for_process,
-    coverage_models => \@coverage_models_for_process,
-    tumor_sample => $discovery_subject,
-    followup_sample => $followup_subject,
-    normal_sample => $germline_subject,
-);
-my $process = $process_command->execute;
-UR::Context->commit;
+my $process = $cle_test->get_process();
 
 Library::wait_for_process($process, $timeout);
 
@@ -143,7 +46,7 @@ UR::Context->current->reload($process);
 
 Library::check_process_failure($process);
 
-my $process_diff_cmd = diff_process($process);
+my $process_diff_cmd = $cle_test->diff_process($process);
 if ($process_diff_cmd) {
     push @diff_cmds, $process_diff_cmd;
 }
@@ -152,76 +55,6 @@ if (@diff_cmds) {
     exit(255);
 }
 # functions
-sub get_sample_from_subject_mapping {
-    my ($anp, $tag) = @_;
-    my $mapping = Genome::Config::AnalysisProject::SubjectMapping->get(analysis_project => $anp,
-        tags => [$tag]);
-    my ($bridge) = $mapping->subject_bridges(label => 'tumor_sample');
-    return $bridge->subject;
-}
-
-sub diff_build {
-    my $build = shift;
-
-    printf("Starting diff (new build = %s)...\n", $build->id);
-
-    my @blessed_builds = Genome::Model::Build->get(id => [qw(
-    185d8bac3d7c4437b7ce9207dfadac7e
-    5f57f08a8fd84886b275f0b5571e9fd7
-    e02e8a5ccaad458d839de51eb47d8d2c
-    26e65adaa8034dd99ef92b27f61ad862
-    3243f261a8b64c089a5254291f7c2de3
-    f87701c292e843958d088e171a65a67a
-    301d5d51c96e41308d015008720f3962
-    )]);
-
-    my $matching_blessed_build;
-    for my $blessed_build (@blessed_builds) {
-        if ($build->tumor_sample eq $blessed_build->tumor_sample and
-                ((!defined($build->normal_sample) and !defined($blessed_build->normal_sample)) or
-                    ($build->normal_sample eq $blessed_build->normal_sample)) and
-            $build->target_region_set_name eq $blessed_build->target_region_set_name) {
-                $matching_blessed_build = $blessed_build;
-                last;
-            }
-    }
-    unless (defined $matching_blessed_build) {
-        fail(sprintf("No matching blessed build found for build %s\n", $build->id));
-    }
-
-    my $diff_cmd = Genome::Model::Build::Command::Diff->create(
-        new_build => $build,
-        blessed_build => $matching_blessed_build,
-    );
-    unless ($diff_cmd->execute) {
-        fail(sprintf("Diff command failed to execute for build %s!\n", $build->id));
-    }
-
-    if (Library::diff_cmd_has_diffs($diff_cmd)) {
-        return $diff_cmd;
-    }
-    return;
-}
-
-sub diff_process {
-    my $process = shift;
-
-    my $blessed_process = Genome::Process->get("2b2b3d8481284fcf8a1632d65ba58083");
-
-    printf("Starting diff (new process = %s)...\n", $process->id);
-    my $diff_cmd = Genome::Process::Command::Diff->create(
-        new_process => $process,
-        blessed_process => $blessed_process,
-    );
-    unless ($diff_cmd->execute) {
-        fail("Diff command failed to execute!\n");
-    }
-
-    if (Library::diff_cmd_has_diffs($diff_cmd)) {
-        return $diff_cmd;
-    }
-    return;
-}
 
 sub fail {
     Library::fail("cle test", @_);

--- a/bin/cle-test
+++ b/bin/cle-test
@@ -106,8 +106,10 @@ my @builds = Genome::Model::Build->get(model_id => [map {$_->id} @models]);
 
 my $start_time = time;
 my @diff_cmds;
+
+my $timeout = Library::get_timeout_seconds(24);
 for my $build (@builds) {
-    wait_for_build($build, $start_time);
+    Library::wait_for_build($build, $start_time, $timeout);
     $build = UR::Context->current->reload('Genome::Model::Build', id => $build->id);
     check_build_failure($build);
     my $diff_cmd = diff_build($build);
@@ -155,35 +157,6 @@ sub get_sample_from_subject_mapping {
         tags => [$tag]);
     my ($bridge) = $mapping->subject_bridges(label => 'tumor_sample');
     return $bridge->subject;
-}
-
-sub wait_for_build {
-    my $build = shift;
-    my $start_time = shift;
-    my $event = $build->the_master_event;
-    unless ($event) {
-        fail("Could not get the build's master event!\n");
-    }
-
-    my $timeout = Library::get_timeout_seconds(24);
-    printf("Monitoring build (%s) until it completes or timeout "
-        . "of %s minutes is reached.\n\n", $build->id, $timeout / 60);
-
-    while (!grep { $event->event_status eq $_ } ('Succeeded',
-            'Failed', 'Crashed')) {
-        UR::Context->current->reload($event);
-        $build = UR::Context->current->reload('Genome::Model::Build', id => $build->id);
-
-        my $elapsed_time = time - $start_time;
-        if ($elapsed_time > $timeout) {
-            printf("Build (%s) timed out after %s minutes",
-                $build->id, $timeout / 60);
-            Library::send_timeout_mail();
-            build_view_and_exit($build);
-        }
-
-        sleep(30);
-    }
 }
 
 sub wait_for_process {

--- a/bin/cle-test
+++ b/bin/cle-test
@@ -111,7 +111,7 @@ my $timeout = Library::get_timeout_seconds(24);
 for my $build (@builds) {
     Library::wait_for_build($build, $start_time, $timeout);
     $build = UR::Context->current->reload('Genome::Model::Build', id => $build->id);
-    check_build_failure($build);
+    Library::check_build_failure($build);
     my $diff_cmd = diff_build($build);
     if (defined $diff_cmd) {
         push @diff_cmds, $diff_cmd;
@@ -136,11 +136,11 @@ my $process_command = Genome::VariantReporting::Command::Wrappers::Trio->create(
 );
 my $process = $process_command->execute;
 UR::Context->commit;
-wait_for_process($process);
+Library::wait_for_process($process);
 
 UR::Context->current->reload($process);
 
-check_process_failure($process);
+Library::check_process_failure($process);
 
 my $process_diff_cmd = diff_process($process);
 if ($process_diff_cmd) {
@@ -157,48 +157,6 @@ sub get_sample_from_subject_mapping {
         tags => [$tag]);
     my ($bridge) = $mapping->subject_bridges(label => 'tumor_sample');
     return $bridge->subject;
-}
-
-sub wait_for_process {
-    my $process = shift;
-
-    my $timeout = Library::get_timeout_seconds(24);
-    printf("Monitoring process (%s) until it completes or timeout "
-        . "of %s minutes is reached.\n\n", $process->id, $timeout / 60);
-
-    my $start_time = time;
-    while (!grep { $process->status eq $_ } ('Succeeded', 'Crashed')) {
-        UR::Context->current->reload($process);
-
-        my $elapsed_time = time - $start_time;
-        if ($elapsed_time > $timeout) {
-            printf("Process (%s) timed out after %s minutes",
-                $process->id, $timeout / 60);
-            Library::send_timeout_mail();
-            process_view_and_exit($process);
-        }
-
-        sleep(30);
-    }
-}
-
-sub process_view_and_exit {
-    my $process = shift;
-    my $pv_command = Genome::Process::Command::View->create(
-        process => $process);
-    $pv_command->execute;
-    exit(255);
-}
-
-sub check_build_failure {
-    my $build = shift;
-
-    if ($build->status eq 'Succeeded') {
-        printf("Build status is %s.\n", $build->status);
-    } else {
-        Library::send_fail_mail();
-        build_view_and_exit($build);
-    }
 }
 
 sub diff_build {
@@ -264,14 +222,6 @@ sub diff_process {
     return;
 }
 
-sub build_view_and_exit {
-    my $build = shift;
-    my $bv_command = Genome::Model::Build::Command::View->create(
-        build => $build);
-    $bv_command->execute;
-    exit(255);
-}
-
 sub fail {
     if (scalar(@_) == 1) {
         print @_;
@@ -284,21 +234,3 @@ sub fail {
     exit(255);
 }
 
-sub check_process_failure {
-    my $process = shift;
-
-    if ($process->status eq 'Succeeded') {
-        printf("Process status is %s.\n", $process->status);
-    } else {
-        Library::send_fail_mail();
-        process_view_and_exit($process);
-    }
-}
-
-sub process_view_and_exit {
-    my $process = shift;
-    my $pv_command = Genome::Process::Command::View->create(
-        process => $process);
-    $pv_command->execute;
-    exit(255);
-}

--- a/bin/cle-test
+++ b/bin/cle-test
@@ -19,9 +19,7 @@ Library::setup_model_process_test();
 Library::set_genome_software_result_test_name();
 
 if (Genome::Sys->username eq 'apipe-tester' && !$ENV{MODEL_TEST_TO}) {
-    if (Users->can('cle')) {
-        $ENV{MODEL_TEST_TO} = Library::users_to_addresses(Users->cle);
-    }
+    $ENV{MODEL_TEST_TO} = Library::users_to_addresses(Users->cle);
 }
 
 my $cmd0 = Genome::Config::AnalysisProject::Command::Create->create(

--- a/bin/cle-test
+++ b/bin/cle-test
@@ -163,7 +163,7 @@ sub get_sample_from_subject_mapping {
 sub diff_build {
     my $build = shift;
 
-    printf('Starting diff (new build = %s)...', $build->id);
+    printf("Starting diff (new build = %s)...\n", $build->id);
 
     my @blessed_builds = Genome::Model::Build->get(id => [qw(
     185d8bac3d7c4437b7ce9207dfadac7e
@@ -208,7 +208,7 @@ sub diff_process {
 
     my $blessed_process = Genome::Process->get("2b2b3d8481284fcf8a1632d65ba58083");
 
-    printf('Starting diff (new process = %s)...', $process->id);
+    printf("Starting diff (new process = %s)...\n", $process->id);
     my $diff_cmd = Genome::Process::Command::Diff->create(
         new_process => $process,
         blessed_process => $blessed_process,

--- a/bin/cle-test
+++ b/bin/cle-test
@@ -97,11 +97,15 @@ UR::Context->commit;
 my @builds = Genome::Model::Build->get(model_id => [map {$_->id} @models]);
 
 my $start_time = time;
+my @diff_cmds;
 for my $build (@builds) {
     wait_for_build($build, $start_time);
     $build = UR::Context->current->reload('Genome::Model::Build', id => $build->id);
     check_build_failure($build);
-    diff_build($build);
+    my $diff_cmd = diff_build($build);
+    if (defined $diff_cmd) {
+        push @diff_cmds, $diff_cmd;
+    }
 }
 
 my $discovery_subject = get_sample_from_subject_mapping($analysis_project, $discovery_tag);
@@ -128,8 +132,14 @@ UR::Context->current->reload($process);
 
 check_process_failure($process);
 
-diff_process($process);
-
+my $process_diff_cmd = diff_process($process);
+if ($process_diff_cmd) {
+    push @diff_cmds, $process_diff_cmd;
+}
+if (@diff_cmds) {
+    Library::send_diff_mail(@diff_cmds);
+    exit(255);
+}
 # functions
 sub get_sample_from_subject_mapping {
     my ($anp, $tag) = @_;
@@ -263,10 +273,9 @@ sub diff_build {
 
     my $has_diffs = (defined($diff_cmd->_diffs) && scalar(keys %{$diff_cmd->_diffs})) || 0;
     if ($has_diffs) {
-        Library::send_diff_mail($diff_cmd);
-        exit(255);
+        return $diff_cmd;
     }
-
+    return;
 }
 
 sub diff_process {
@@ -285,10 +294,9 @@ sub diff_process {
 
     my $has_diffs = (defined($diff_cmd->_diffs) && scalar(keys %{$diff_cmd->_diffs})) || 0;
     if ($has_diffs) {
-        Library::send_diff_mail($diff_cmd);
-        exit(255);
+        return $diff_cmd;
     }
-
+    return;
 }
 
 sub build_view_and_exit {

--- a/bin/cle-test
+++ b/bin/cle-test
@@ -271,8 +271,7 @@ sub diff_build {
         fail(sprintf("Diff command failed to execute for build %s!\n", $build->id));
     }
 
-    my $has_diffs = (defined($diff_cmd->_diffs) && scalar(keys %{$diff_cmd->_diffs})) || 0;
-    if ($has_diffs) {
+    if (Library::diff_cmd_has_diffs($diff_cmd)) {
         return $diff_cmd;
     }
     return;
@@ -292,8 +291,7 @@ sub diff_process {
         fail("Diff command failed to execute!\n");
     }
 
-    my $has_diffs = (defined($diff_cmd->_diffs) && scalar(keys %{$diff_cmd->_diffs})) || 0;
-    if ($has_diffs) {
+    if (Library::diff_cmd_has_diffs($diff_cmd)) {
         return $diff_cmd;
     }
     return;

--- a/bin/cle-test
+++ b/bin/cle-test
@@ -5,10 +5,10 @@ use Revision;
 use Library;
 use Users;
 use JenkinsData;
+use Try::Tiny qw(try catch);
 
 use strict;
 use warnings;
-
 
 # flush output buffer after every write or print
 local $| = 1;
@@ -22,7 +22,12 @@ if (Genome::Sys->username eq 'apipe-tester' && !$ENV{MODEL_TEST_TO}) {
 }
 
 my $cle_test = Genome::Site::TGI::CleTest->create();
-my @builds = $cle_test->get_builds();
+my @builds = try {
+    $cle_test->get_builds();
+}
+catch {
+    fail($_);
+};
 
 my $start_time = time;
 my @diff_cmds;
@@ -32,13 +37,23 @@ for my $build (@builds) {
     Library::wait_for_build($build, $start_time, $timeout);
     UR::Context->current->reload($build);
     Library::check_build_failure($build);
-    my $diff_cmd = $cle_test->diff_build($build);
+    my $diff_cmd = try {
+        $cle_test->diff_build($build);
+    }
+    catch {
+        fail($_);
+    };
     if (defined $diff_cmd) {
         push @diff_cmds, $diff_cmd;
     }
 }
 
-my $process = $cle_test->get_process();
+my $process = try {
+    $cle_test->get_process();
+}
+catch {
+    fail($_);
+};
 
 Library::wait_for_process($process, $timeout);
 
@@ -46,7 +61,12 @@ UR::Context->current->reload($process);
 
 Library::check_process_failure($process);
 
-my $process_diff_cmd = $cle_test->diff_process($process);
+my $process_diff_cmd = try {
+    $cle_test->diff_process($process);
+}
+catch {
+    fail($_);
+};
 if ($process_diff_cmd) {
     push @diff_cmds, $process_diff_cmd;
 }

--- a/bin/cle-test
+++ b/bin/cle-test
@@ -50,11 +50,10 @@ H_KA-174556-1309246					germline
 SUBJECT_MAPPINGS
 
 Genome::Sys->write_file($subject_mapping_file, $subject_mapping);
-my $cmd4 = Genome::Config::AnalysisProject::SubjectMapping::Command::Import::SomaticValidation->create(
+Genome::Config::AnalysisProject::SubjectMapping::Command::Import::SomaticValidation->execute(
     analysis_project => $analysis_project,
     file_path => $subject_mapping_file,
 );
-$cmd4->execute;
 
 my @instrument_data = qw(2893814999 2893815000 2893815001 2893815002 2893815003 2893815016 2893815018 2893815020 2893815023 2893815024 2893815447 2893815448 2893815449 2893815451 2893815484 2893815485 2893815489 2893815492);
 for my $id (@instrument_data) {
@@ -66,18 +65,16 @@ for my $id (@instrument_data) {
     );
 }
 
-my $cmd5 = Genome::Config::AnalysisProject::Command::Release->create(
+Genome::Config::AnalysisProject::Command::Release->execute(
     analysis_projects => [$analysis_project],
 );
-$cmd5->execute;
 
 my @instrument_data_objects = Genome::InstrumentData->get(id => \@instrument_data);
 my @pre_cqid_models = Genome::Model->get();
 my $pre_cqid_model_count = scalar @pre_cqid_models;
-my $cmd6 = Genome::Config::Command::ConfigureQueuedInstrumentData->create(
+Genome::Config::Command::ConfigureQueuedInstrumentData->execute(
     instrument_data => \@instrument_data_objects,
 );
-$cmd6->execute;
 my @post_cqid_models = Genome::Model->get();
 my $post_cqid_model_count = scalar @post_cqid_models;
 my $expected_number_of_models = 7;
@@ -89,10 +86,9 @@ unless ($actual_number_of_models == $expected_number_of_models) {
 }
 
 my @models = Genome::Model->get(analysis_project => $analysis_project);
-my $start_cmd = Genome::Model::Build::Command::Start->create(
+Genome::Model::Build::Command::Start->execute(
     models => \@models,
 );
-$start_cmd->execute;
 UR::Context->commit;
 my @builds = Genome::Model::Build->get(model_id => [map {$_->id} @models]);
 
@@ -119,14 +115,13 @@ my @models_for_process = Genome::Model::SomaticValidation->get(analysis_project 
 my @coverage_models_for_process = Genome::Model::SomaticValidation->get(analysis_project => $analysis_project,
     tumor_sample => [$discovery_subject, $followup_subject]);
 my @germline_models = grep {$_->tumor_sample eq $germline_subject} @models_for_process;
-my $process_command = Genome::VariantReporting::Command::Wrappers::Trio->create(
+Genome::VariantReporting::Command::Wrappers::Trio->execute(
     models => \@models_for_process,
     coverage_models => \@coverage_models_for_process,
     tumor_sample => $discovery_subject,
     followup_sample => $followup_subject,
     normal_sample => $germline_subject,
 );
-my $process = $process_command->execute;
 UR::Context->commit;
 
 Library::wait_for_process($process, $timeout);

--- a/bin/cle-test
+++ b/bin/cle-test
@@ -99,13 +99,14 @@ my @models_for_process = Genome::Model::SomaticValidation->get(analysis_project 
 my @coverage_models_for_process = Genome::Model::SomaticValidation->get(analysis_project => $analysis_project,
     tumor_sample => [$discovery_subject, $followup_subject]);
 my @germline_models = grep {$_->tumor_sample eq $germline_subject} @models_for_process;
-Genome::VariantReporting::Command::Wrappers::Trio->execute(
+my $process_cmd = Genome::VariantReporting::Command::Wrappers::Trio->create(
     models => \@models_for_process,
     coverage_models => \@coverage_models_for_process,
     tumor_sample => $discovery_subject,
     followup_sample => $followup_subject,
     normal_sample => $germline_subject,
 );
+my $process = $process_cmd->execute;
 UR::Context->commit;
 
 Library::wait_for_process($process, $timeout);

--- a/bin/cle-test
+++ b/bin/cle-test
@@ -223,14 +223,6 @@ sub diff_process {
 }
 
 sub fail {
-    if (scalar(@_) == 1) {
-        print @_;
-    } elsif (scalar(@_) > 1) {
-        printf @_;
-    } else {
-        print "Failed to execute cle test\n";
-    }
-
-    exit(255);
+    Library::fail("cle test", @_);
 }
 

--- a/bin/cle-test
+++ b/bin/cle-test
@@ -27,29 +27,21 @@ my $cmd0 = Genome::Config::AnalysisProject::Command::Create->create(
     no_config => 1
 );
 my $analysis_project = $cmd0->execute;
-my $menu_item1 = Genome::Config::AnalysisMenu::Item->get("9ab6e28f832a428393b87b171d444401");
-my $menu_item2 = Genome::Config::AnalysisMenu::Item->get("3770b8510d5a459f9c0bb01fabf56337");
-my $discovery_tag = Genome::Config::Tag->get(name => 'discovery');
-my $followup_tag = Genome::Config::Tag->get(name => 'followup');
-my $germline_tag = Genome::Config::Tag->get(name => 'germline');
-my $cmd1 = Genome::Config::AnalysisProject::Command::AddMenuItem->create(
-    analysis_menu_items => $menu_item1,
-    tags => $discovery_tag,
-    analysis_project => $analysis_project,
+my %tag_to_menu_item = (
+    discovery => "9ab6e28f832a428393b87b171d444401",
+    followup => "9ab6e28f832a428393b87b171d444401",
+    germline => "3770b8510d5a459f9c0bb01fabf56337",
 );
-$cmd1->execute;
-my $cmd2 = Genome::Config::AnalysisProject::Command::AddMenuItem->create(
-    analysis_menu_items => $menu_item1,
-    tags => $followup_tag,
-    analysis_project => $analysis_project,
-);
-$cmd2->execute;
-my $cmd3 = Genome::Config::AnalysisProject::Command::AddMenuItem->create(
-    analysis_menu_items => $menu_item2,
-    tags => $germline_tag,
-    analysis_project => $analysis_project,
-);
-$cmd3->execute;
+while (my ($tag_name, $menu_item_id) = each %tag_to_menu_item) {
+    my $menu_item = Genome::Config::AnalysisMenu::Item->get($menu_item_id);
+    my $tag = Genome::Config::Tag->get(name => $tag_name);
+    Genome::Config::AnalysisProject::Command::AddMenuItem->execute(
+        analysis_menu_items => $menu_item,
+        tags => $tag,
+        analysis_project => $analysis_project,
+    );
+}
+
 my $subject_mapping_file = Genome::Sys->create_temp_file_path;
 my $subject_mapping = <<'SUBJECT_MAPPINGS';
 H_KA-174556-1309237	H_KA-174556-1309246				followup

--- a/bin/cle-test
+++ b/bin/cle-test
@@ -110,7 +110,7 @@ my @diff_cmds;
 my $timeout = Library::get_timeout_seconds(24);
 for my $build (@builds) {
     Library::wait_for_build($build, $start_time, $timeout);
-    $build = UR::Context->current->reload('Genome::Model::Build', id => $build->id);
+    UR::Context->current->reload($build);
     Library::check_build_failure($build);
     my $diff_cmd = diff_build($build);
     if (defined $diff_cmd) {

--- a/bin/cle-test
+++ b/bin/cle-test
@@ -177,7 +177,7 @@ sub diff_build {
     my $matching_blessed_build;
     for my $blessed_build (@blessed_builds) {
         if ($build->tumor_sample eq $blessed_build->tumor_sample and
-                (($build->normal_sample == undef and $blessed_build->normal_sample == undef) or
+                ((!defined($build->normal_sample) and !defined($blessed_build->normal_sample)) or
                     ($build->normal_sample eq $blessed_build->normal_sample)) and
             $build->target_region_set_name eq $blessed_build->target_region_set_name) {
                 $matching_blessed_build = $blessed_build;

--- a/bin/cle-test
+++ b/bin/cle-test
@@ -104,21 +104,9 @@ for my $build (@builds) {
     diff_build($build);
 }
 
-my $discovery_mapping = Genome::Config::AnalysisProject::SubjectMapping->get(analysis_project => $analysis_project,
-    tags => [$discovery_tag]);
-my @bridges = grep {$_->label eq 'tumor_sample'} $discovery_mapping->subject_bridges;
-my $bridge = $bridges[0];
-my $discovery_subject = $bridge->subject;
-my $followup_mapping = Genome::Config::AnalysisProject::SubjectMapping->get(analysis_project => $analysis_project,
-    tags => [$followup_tag]);
-@bridges = grep {$_->label eq 'tumor_sample'} $followup_mapping->subject_bridges;
-$bridge = $bridges[0];
-my $followup_subject = $bridge->subject;
-my $germline_mapping = Genome::Config::AnalysisProject::SubjectMapping->get(analysis_project => $analysis_project,
-    tags => [$germline_tag]);
-@bridges = grep {$_->label eq 'tumor_sample'} $germline_mapping->subject_bridges;
-$bridge = $bridges[0];
-my $germline_subject = $bridge->subject;
+my $discovery_subject = get_sample_from_subject_mapping($analysis_project, $discovery_tag);
+my $followup_subject = get_sample_from_subject_mapping($analysis_project, $followup_tag);
+my $germline_subject = get_sample_from_subject_mapping($analysis_project, $germline_tag);
 
 my @models_for_process = Genome::Model::SomaticValidation->get(analysis_projects => [$analysis_project],
     region_of_interest_set_name => 'SeqCap EZ Human Exome v3.0 + AML RMG pooled probes + WO2830729 pooled probes + WO2840081 pooled probes');
@@ -143,6 +131,15 @@ check_process_failure($process);
 diff_process($process);
 
 # functions
+sub get_sample_from_subject_mapping {
+    my ($anp, $tag) = @_;
+    my $mapping = Genome::Config::AnalysisProject::SubjectMapping->get(analysis_project => $anp,
+        tags => [$tag]);
+    my @bridges = grep {$_->label eq 'tumor_sample'} $mapping->subject_bridges;
+    my $bridge = $bridges[0];
+    return $bridge->subject;
+}
+
 sub get_timeout {
     my $timeout_hours = 14;
     my $timeout_seconds = $timeout_hours * 3600;

--- a/bin/cle-test
+++ b/bin/cle-test
@@ -90,9 +90,9 @@ for my $build (@builds) {
     }
 }
 
-my $discovery_subject = get_sample_from_subject_mapping($analysis_project, $discovery_tag);
-my $followup_subject = get_sample_from_subject_mapping($analysis_project, $followup_tag);
-my $germline_subject = get_sample_from_subject_mapping($analysis_project, $germline_tag);
+my $discovery_subject = get_sample_from_subject_mapping($analysis_project, 'discovery');
+my $followup_subject = get_sample_from_subject_mapping($analysis_project, 'followup');
+my $germline_subject = get_sample_from_subject_mapping($analysis_project, 'germline');
 
 my @models_for_process = Genome::Model::SomaticValidation->get(analysis_project => $analysis_project,
     region_of_interest_set_name => $test_config->{region_of_interest_set_name});
@@ -124,7 +124,8 @@ if (@diff_cmds) {
 }
 # functions
 sub get_sample_from_subject_mapping {
-    my ($anp, $tag) = @_;
+    my ($anp, $tag_name) = @_;
+    my $tag = Genome::Config::Tag->get(name => $tag_name);
     my $mapping = Genome::Config::AnalysisProject::SubjectMapping->get(analysis_project => $anp,
         tags => [$tag]);
     my ($bridge) = $mapping->subject_bridges(label => 'tumor_sample');

--- a/bin/cle-test
+++ b/bin/cle-test
@@ -1,0 +1,334 @@
+#!/usr/bin/perl
+
+use Genome;
+use Revision;
+use Library;
+use Users;
+use JenkinsData;
+use Memoize qw(memoize);
+
+use strict;
+use warnings;
+
+
+# flush output buffer after every write or print
+local $| = 1;
+Library::setup_model_process_test();
+
+
+Library::set_genome_software_result_test_name();
+
+if (Genome::Sys->username eq 'apipe-tester' && !$ENV{MODEL_TEST_TO}) {
+    if (Users->can('cle')) {
+        $ENV{MODEL_TEST_TO} = Library::users_to_addresses(Users->cle);
+    }
+}
+
+my $cmd0 = Genome::Config::AnalysisProject::Command::Create->create(
+    environment => "ad-hoc",
+    name => "CLE Test",
+    no_config => 1
+);
+my $analysis_project = $cmd0->execute;
+my $menu_item1 = Genome::Config::AnalysisMenu::Item->get("9ab6e28f832a428393b87b171d444401");
+my $menu_item2 = Genome::Config::AnalysisMenu::Item->get("3770b8510d5a459f9c0bb01fabf56337");
+my $discovery_tag = Genome::Config::Tag->get(name => 'discovery');
+my $followup_tag = Genome::Config::Tag->get(name => 'followup');
+my $germline_tag = Genome::Config::Tag->get(name => 'germline');
+my $cmd1 = Genome::Config::AnalysisProject::Command::AddMenuItem->create(
+    analysis_menu_items => $menu_item1,
+    tags => $discovery_tag,
+    analysis_project => $analysis_project,
+);
+$cmd1->execute;
+my $cmd2 = Genome::Config::AnalysisProject::Command::AddMenuItem->create(
+    analysis_menu_items => $menu_item1,
+    tags => $followup_tag,
+    analysis_project => $analysis_project,
+);
+$cmd2->execute;
+my $cmd3 = Genome::Config::AnalysisProject::Command::AddMenuItem->create(
+    analysis_menu_items => $menu_item2,
+    tags => $germline_tag,
+    analysis_project => $analysis_project,
+);
+$cmd3->execute;
+my $subject_mapping_file = Genome::Sys->create_temp_file_path;
+my $subject_mapping = <<'SUBJECT_MAPPINGS';
+H_KA-174556-1309237	H_KA-174556-1309246				followup
+H_KA-174556-1309245	H_KA-174556-1309246				discovery
+H_KA-174556-1309246					germline
+SUBJECT_MAPPINGS
+
+Genome::Sys->write_file($subject_mapping_file, $subject_mapping);
+my $cmd4 = Genome::Config::AnalysisProject::SubjectMapping::Command::Import::SomaticValidation->create(
+    analysis_project => $analysis_project,
+    file_path => $subject_mapping_file,
+);
+$cmd4->execute;
+
+my @instrument_data = qw(2893814999 2893815000 2893815001 2893815002 2893815003 2893815016 2893815018 2893815020 2893815023 2893815024 2893815447 2893815448 2893815449 2893815451 2893815484 2893815485 2893815489 2893815492);
+for my $id (@instrument_data) {
+    my $instrument_data = Genome::InstrumentData->get($id);
+    Genome::Config::AnalysisProject::InstrumentDataBridge->create(
+        analysis_project => $analysis_project,
+        instrument_data => $instrument_data,
+        status => 'new',
+    );
+}
+
+my $cmd5 = Genome::Config::AnalysisProject::Command::Release->create(
+    analysis_projects => [$analysis_project],
+);
+$cmd5->execute;
+
+my @instrument_data_objects = Genome::InstrumentData->get(id => \@instrument_data);
+my $cmd6 = Genome::Config::Command::ConfigureQueuedInstrumentData->create(
+    instrument_data => \@instrument_data_objects,
+);
+$cmd6->execute;
+
+my @models = Genome::Model->get(analysis_projects => [$analysis_project]);
+my $start_cmd = Genome::Model::Build::Command::Start->create(
+    models => \@models,
+);
+$start_cmd->execute;
+UR::Context->commit;
+my @builds = Genome::Model::Build->get(model_id => [map {$_->id} @models]);
+
+my $start_time = time;
+for my $build (@builds) {
+    wait_for_build($build, $start_time);
+    $build = UR::Context->current->reload('Genome::Model::Build', id => $build->id);
+    check_build_failure($build);
+    diff_build($build);
+}
+
+my $discovery_mapping = Genome::Config::AnalysisProject::SubjectMapping->get(analysis_project => $analysis_project,
+    tags => [$discovery_tag]);
+my @bridges = grep {$_->label eq 'tumor_sample'} $discovery_mapping->subject_bridges;
+my $bridge = $bridges[0];
+my $discovery_subject = $bridge->subject;
+my $followup_mapping = Genome::Config::AnalysisProject::SubjectMapping->get(analysis_project => $analysis_project,
+    tags => [$followup_tag]);
+@bridges = grep {$_->label eq 'tumor_sample'} $followup_mapping->subject_bridges;
+$bridge = $bridges[0];
+my $followup_subject = $bridge->subject;
+my $germline_mapping = Genome::Config::AnalysisProject::SubjectMapping->get(analysis_project => $analysis_project,
+    tags => [$germline_tag]);
+@bridges = grep {$_->label eq 'tumor_sample'} $germline_mapping->subject_bridges;
+$bridge = $bridges[0];
+my $germline_subject = $bridge->subject;
+
+my @models_for_process = Genome::Model::SomaticValidation->get(analysis_projects => [$analysis_project],
+    region_of_interest_set_name => 'SeqCap EZ Human Exome v3.0 + AML RMG pooled probes + WO2830729 pooled probes + WO2840081 pooled probes');
+my @coverage_models_for_process = Genome::Model::SomaticValidation->get(analysis_projects => [$analysis_project],
+    tumor_sample => [$discovery_subject, $followup_subject]);
+my @germline_models = grep {$_->tumor_sample eq $germline_subject} @models_for_process;
+my $process_command = Genome::VariantReporting::Command::Wrappers::Trio->create(
+    models => \@models_for_process,
+    coverage_models => \@coverage_models_for_process,
+    tumor_sample => $discovery_subject,
+    followup_sample => $followup_subject,
+    normal_sample => $germline_subject,
+);
+my $process = $process_command->execute;
+UR::Context->commit;
+wait_for_process($process);
+
+UR::Context->current->reload($process);
+
+check_process_failure($process);
+
+diff_process($process);
+
+# functions
+sub get_timeout {
+    my $timeout_hours = 14;
+    my $timeout_seconds = $timeout_hours * 3600;
+
+    return $timeout_seconds;
+}
+
+sub get_process_timeout {
+    my $timeout_hours = 14;
+    my $timeout_seconds = $timeout_hours * 3600;
+
+    return $timeout_seconds;
+}
+
+sub wait_for_build {
+    my $build = shift;
+    my $start_time = shift;
+    my $event = $build->the_master_event;
+    unless ($event) {
+        fail("Could not get the build's master event!\n");
+    }
+
+    my $timeout = get_timeout();
+    printf("Monitoring build (%s) until it completes or timeout "
+        . "of %s minutes is reached.\n\n", $build->id, $timeout / 60);
+
+    while (!grep { $event->event_status eq $_ } ('Succeeded',
+            'Failed', 'Crashed')) {
+        UR::Context->current->reload($event);
+
+        my $elapsed_time = time - $start_time;
+        if ($elapsed_time > $timeout) {
+            printf("Build (%s) timed out after %s minutes",
+                $build->id, $timeout / 60);
+            Library::send_timeout_mail();
+            build_view_and_exit($build);
+        }
+
+        sleep(30);
+    }
+}
+
+sub wait_for_process {
+    my $process = shift;
+
+    my $timeout = get_process_timeout();
+    printf("Monitoring process (%s) until it completes or timeout "
+        . "of %s minutes is reached.\n\n", $process->id, $timeout / 60);
+
+    my $start_time = time;
+    while (!grep { $process->status eq $_ } ('Succeeded', 'Crashed')) {
+        UR::Context->current->reload($process);
+
+        my $elapsed_time = time - $start_time;
+        if ($elapsed_time > $timeout) {
+            printf("Process (%s) timed out after %s minutes",
+                $process->id, $timeout / 60);
+            Library::send_timeout_mail();
+            process_view_and_exit($process);
+        }
+
+        sleep(30);
+    }
+}
+
+sub process_view_and_exit {
+    my $process = shift;
+    my $pv_command = Genome::Process::Command::View->create(
+        process => $process);
+    $pv_command->execute;
+    exit(255);
+}
+
+sub check_build_failure {
+    my $build = shift;
+
+    if ($build->status eq 'Succeeded') {
+        printf("Build status is %s.\n", $build->status);
+    } else {
+        Library::send_fail_mail();
+        build_view_and_exit($build);
+    }
+}
+
+sub diff_build {
+    my $build = shift;
+
+    printf('Starting diff (new build = %s)...', $build->id);
+
+    my @blessed_builds = Genome::Model::Build->get(id => [qw(
+    185d8bac3d7c4437b7ce9207dfadac7e
+    5f57f08a8fd84886b275f0b5571e9fd7
+    e02e8a5ccaad458d839de51eb47d8d2c
+    26e65adaa8034dd99ef92b27f61ad862
+    3243f261a8b64c089a5254291f7c2de3
+    f87701c292e843958d088e171a65a67a
+    301d5d51c96e41308d015008720f3962
+    )]);
+
+    my $matching_blessed_build;
+    for my $blessed_build (@blessed_builds) {
+        if ($build->tumor_sample eq $blessed_build->tumor_sample and
+                (($build->normal_sample == undef and $blessed_build->normal_sample == undef) or
+                    ($build->normal_sample eq $blessed_build->normal_sample)) and
+            $build->target_region_set_name eq $blessed_build->target_region_set_name) {
+                $matching_blessed_build = $blessed_build;
+                last;
+            }
+    }
+    unless (defined $matching_blessed_build) {
+        fail(sprintf("No matching blessed build found for build %s\n", $build->id));
+    }
+
+    my $diff_cmd = Genome::Model::Build::Command::Diff->create(
+        new_build => $build,
+        blessed_build => $matching_blessed_build,
+    );
+    unless ($diff_cmd->execute) {
+        fail(sprintf("Diff command failed to execute for build %s!\n", $build->id));
+    }
+
+    my $has_diffs = (defined($diff_cmd->_diffs) && scalar(keys %{$diff_cmd->_diffs})) || 0;
+    if ($has_diffs) {
+        Library::send_diff_mail($diff_cmd);
+        exit(255);
+    }
+
+}
+
+sub diff_process {
+    my $process = shift;
+
+    my $blessed_process = Genome::Process->get("2b2b3d8481284fcf8a1632d65ba58083");
+
+    printf('Starting diff (new process = %s)...', $process->id);
+    my $diff_cmd = Genome::Process::Command::Diff->create(
+        new_process => $process,
+        blessed_process => $blessed_process,
+    );
+    unless ($diff_cmd->execute) {
+        fail("Diff command failed to execute!\n");
+    }
+
+    my $has_diffs = (defined($diff_cmd->_diffs) && scalar(keys %{$diff_cmd->_diffs})) || 0;
+    if ($has_diffs) {
+        Library::send_diff_mail($diff_cmd);
+        exit(255);
+    }
+
+}
+
+sub build_view_and_exit {
+    my $build = shift;
+    my $bv_command = Genome::Model::Build::Command::View->create(
+        build => $build);
+    $bv_command->execute;
+    exit(255);
+}
+
+sub fail {
+    if (scalar(@_) == 1) {
+        print @_;
+    } elsif (scalar(@_) > 1) {
+        printf @_;
+    } else {
+        print "Failed to execute cle test\n";
+    }
+
+    exit(255);
+}
+
+sub check_process_failure {
+    my $process = shift;
+
+    if ($process->status eq 'Succeeded') {
+        printf("Process status is %s.\n", $process->status);
+    } else {
+        Library::send_fail_mail();
+        process_view_and_exit($process);
+    }
+}
+
+sub process_view_and_exit {
+    my $process = shift;
+    my $pv_command = Genome::Process::Command::View->create(
+        process => $process);
+    $pv_command->execute;
+    exit(255);
+}

--- a/bin/cle-test
+++ b/bin/cle-test
@@ -83,12 +83,14 @@ my $cmd5 = Genome::Config::AnalysisProject::Command::Release->create(
 $cmd5->execute;
 
 my @instrument_data_objects = Genome::InstrumentData->get(id => \@instrument_data);
-my $pre_cqid_model_count = Genome::Model->get();
+my @pre_cqid_models = Genome::Model->get();
+my $pre_cqid_model_count = scalar @pre_cqid_models;
 my $cmd6 = Genome::Config::Command::ConfigureQueuedInstrumentData->create(
     instrument_data => \@instrument_data_objects,
 );
 $cmd6->execute;
-my $post_cqid_model_count = Genome::Model->get();
+my @post_cqid_models = Genome::Model->get();
+my $post_cqid_model_count = scalar @post_cqid_models;
 my $expected_number_of_models = 7;
 my $actual_number_of_models = $post_cqid_model_count - $pre_cqid_model_count;
 unless ($actual_number_of_models == $expected_number_of_models) {

--- a/bin/cle-test
+++ b/bin/cle-test
@@ -5,7 +5,6 @@ use Revision;
 use Library;
 use Users;
 use JenkinsData;
-use Memoize qw(memoize);
 
 use strict;
 use warnings;

--- a/bin/cle-test
+++ b/bin/cle-test
@@ -157,20 +157,6 @@ sub get_sample_from_subject_mapping {
     return $bridge->subject;
 }
 
-sub get_timeout {
-    my $timeout_hours = 24;
-    my $timeout_seconds = $timeout_hours * 3600;
-
-    return $timeout_seconds;
-}
-
-sub get_process_timeout {
-    my $timeout_hours = 24;
-    my $timeout_seconds = $timeout_hours * 3600;
-
-    return $timeout_seconds;
-}
-
 sub wait_for_build {
     my $build = shift;
     my $start_time = shift;
@@ -179,7 +165,7 @@ sub wait_for_build {
         fail("Could not get the build's master event!\n");
     }
 
-    my $timeout = get_timeout();
+    my $timeout = Library::get_timeout_seconds(24);
     printf("Monitoring build (%s) until it completes or timeout "
         . "of %s minutes is reached.\n\n", $build->id, $timeout / 60);
 
@@ -203,7 +189,7 @@ sub wait_for_build {
 sub wait_for_process {
     my $process = shift;
 
-    my $timeout = get_process_timeout();
+    my $timeout = Library::get_timeout_seconds(24);
     printf("Monitoring process (%s) until it completes or timeout "
         . "of %s minutes is reached.\n\n", $process->id, $timeout / 60);
 

--- a/bin/cle-test
+++ b/bin/cle-test
@@ -156,8 +156,7 @@ sub get_sample_from_subject_mapping {
     my ($anp, $tag) = @_;
     my $mapping = Genome::Config::AnalysisProject::SubjectMapping->get(analysis_project => $anp,
         tags => [$tag]);
-    my @bridges = grep {$_->label eq 'tumor_sample'} $mapping->subject_bridges;
-    my $bridge = $bridges[0];
+    my ($bridge) = $mapping->subject_bridges(label => 'tumor_sample');
     return $bridge->subject;
 }
 

--- a/bin/cle-test
+++ b/bin/cle-test
@@ -5,6 +5,7 @@ use Revision;
 use Library;
 use Users;
 use JenkinsData;
+use Genome::Site::TGI::CleTest;
 
 use strict;
 use warnings;
@@ -14,8 +15,9 @@ use warnings;
 local $| = 1;
 Library::setup_model_process_test();
 
-
 Library::set_genome_software_result_test_name();
+
+my $test_config = Genome;:Site::TGI::CleTest::get_config;
 
 if (Genome::Sys->username eq 'apipe-tester' && !$ENV{MODEL_TEST_TO}) {
     $ENV{MODEL_TEST_TO} = Library::users_to_addresses(Users->cle);
@@ -27,11 +29,9 @@ my $cmd0 = Genome::Config::AnalysisProject::Command::Create->create(
     no_config => 1
 );
 my $analysis_project = $cmd0->execute;
-my %tag_to_menu_item = (
-    discovery => "9ab6e28f832a428393b87b171d444401",
-    followup => "9ab6e28f832a428393b87b171d444401",
-    germline => "3770b8510d5a459f9c0bb01fabf56337",
-);
+
+my %tag_to_menu_item = %{$test_config->{tag_to_menu_item}};
+
 while (my ($tag_name, $menu_item_id) = each %tag_to_menu_item) {
     my $menu_item = Genome::Config::AnalysisMenu::Item->get($menu_item_id);
     my $tag = Genome::Config::Tag->get(name => $tag_name);
@@ -43,19 +43,14 @@ while (my ($tag_name, $menu_item_id) = each %tag_to_menu_item) {
 }
 
 my $subject_mapping_file = Genome::Sys->create_temp_file_path;
-my $subject_mapping = <<'SUBJECT_MAPPINGS';
-H_KA-174556-1309237	H_KA-174556-1309246				followup
-H_KA-174556-1309245	H_KA-174556-1309246				discovery
-H_KA-174556-1309246					germline
-SUBJECT_MAPPINGS
-
+my $subject_mapping = $test_config->{subject_mapping_string};
 Genome::Sys->write_file($subject_mapping_file, $subject_mapping);
 Genome::Config::AnalysisProject::SubjectMapping::Command::Import::SomaticValidation->execute(
     analysis_project => $analysis_project,
     file_path => $subject_mapping_file,
 );
 
-my @instrument_data = qw(2893814999 2893815000 2893815001 2893815002 2893815003 2893815016 2893815018 2893815020 2893815023 2893815024 2893815447 2893815448 2893815449 2893815451 2893815484 2893815485 2893815489 2893815492);
+my @instrument_data = @{$test_config->{instrument_data}};
 for my $id (@instrument_data) {
     my $instrument_data = Genome::InstrumentData->get($id);
     Genome::Config::AnalysisProject::InstrumentDataBridge->create(
@@ -100,7 +95,7 @@ my $followup_subject = get_sample_from_subject_mapping($analysis_project, $follo
 my $germline_subject = get_sample_from_subject_mapping($analysis_project, $germline_tag);
 
 my @models_for_process = Genome::Model::SomaticValidation->get(analysis_project => $analysis_project,
-    region_of_interest_set_name => 'SeqCap EZ Human Exome v3.0 + AML RMG pooled probes + WO2830729 pooled probes + WO2840081 pooled probes');
+    region_of_interest_set_name => $test_config->{region_of_interest_set_name});
 my @coverage_models_for_process = Genome::Model::SomaticValidation->get(analysis_project => $analysis_project,
     tumor_sample => [$discovery_subject, $followup_subject]);
 my @germline_models = grep {$_->tumor_sample eq $germline_subject} @models_for_process;
@@ -141,15 +136,7 @@ sub diff_build {
 
     printf("Starting diff (new build = %s)...\n", $build->id);
 
-    my @blessed_builds = Genome::Model::Build->get(id => [qw(
-    185d8bac3d7c4437b7ce9207dfadac7e
-    5f57f08a8fd84886b275f0b5571e9fd7
-    e02e8a5ccaad458d839de51eb47d8d2c
-    26e65adaa8034dd99ef92b27f61ad862
-    3243f261a8b64c089a5254291f7c2de3
-    f87701c292e843958d088e171a65a67a
-    301d5d51c96e41308d015008720f3962
-    )]);
+    my @blessed_builds = Genome::Model::Build->get(id => $test_config->{blessed_builds});
 
     my $matching_blessed_build;
     for my $blessed_build (@blessed_builds) {
@@ -182,7 +169,7 @@ sub diff_build {
 sub diff_process {
     my $process = shift;
 
-    my $blessed_process = Genome::Process->get("2b2b3d8481284fcf8a1632d65ba58083");
+    my $blessed_process = Genome::Process->get($test_config->{blessed_process});
 
     printf("Starting diff (new process = %s)...\n", $process->id);
     my $diff_cmd = Genome::Process::Command::Diff->create(

--- a/bin/cle-test
+++ b/bin/cle-test
@@ -5,10 +5,10 @@ use Revision;
 use Library;
 use Users;
 use JenkinsData;
-use Try::Tiny qw(try catch);
 
 use strict;
 use warnings;
+
 
 # flush output buffer after every write or print
 local $| = 1;
@@ -22,12 +22,7 @@ if (Genome::Sys->username eq 'apipe-tester' && !$ENV{MODEL_TEST_TO}) {
 }
 
 my $cle_test = Genome::Site::TGI::CleTest->create();
-my @builds = try {
-    $cle_test->get_builds();
-}
-catch {
-    fail($_);
-};
+my @builds = $cle_test->get_builds();
 
 my $start_time = time;
 my @diff_cmds;
@@ -37,23 +32,13 @@ for my $build (@builds) {
     Library::wait_for_build($build, $start_time, $timeout);
     UR::Context->current->reload($build);
     Library::check_build_failure($build);
-    my $diff_cmd = try {
-        $cle_test->diff_build($build);
-    }
-    catch {
-        fail($_);
-    };
+    my $diff_cmd = $cle_test->diff_build($build);
     if (defined $diff_cmd) {
         push @diff_cmds, $diff_cmd;
     }
 }
 
-my $process = try {
-    $cle_test->get_process();
-}
-catch {
-    fail($_);
-};
+my $process = $cle_test->get_process();
 
 Library::wait_for_process($process, $timeout);
 
@@ -61,12 +46,7 @@ UR::Context->current->reload($process);
 
 Library::check_process_failure($process);
 
-my $process_diff_cmd = try {
-    $cle_test->diff_process($process);
-}
-catch {
-    fail($_);
-};
+my $process_diff_cmd = $cle_test->diff_process($process);
 if ($process_diff_cmd) {
     push @diff_cmds, $process_diff_cmd;
 }

--- a/bin/cle-test
+++ b/bin/cle-test
@@ -17,7 +17,7 @@ Library::setup_model_process_test();
 
 Library::set_genome_software_result_test_name();
 
-my $test_config = Genome;:Site::TGI::CleTest::get_config;
+my $test_config = Genome::Site::TGI::CleTest::get_config();
 
 if (Genome::Sys->username eq 'apipe-tester' && !$ENV{MODEL_TEST_TO}) {
     $ENV{MODEL_TEST_TO} = Library::users_to_addresses(Users->cle);

--- a/bin/cle-test
+++ b/bin/cle-test
@@ -190,6 +190,7 @@ sub wait_for_build {
     while (!grep { $event->event_status eq $_ } ('Succeeded',
             'Failed', 'Crashed')) {
         UR::Context->current->reload($event);
+        $build = UR::Context->current->reload('Genome::Model::Build', id => $build->id);
 
         my $elapsed_time = time - $start_time;
         if ($elapsed_time > $timeout) {

--- a/bin/cle-test
+++ b/bin/cle-test
@@ -96,7 +96,7 @@ unless ($actual_number_of_models == $expected_number_of_models) {
         $actual_number_of_models));
 }
 
-my @models = Genome::Model->get(analysis_projects => [$analysis_project]);
+my @models = Genome::Model->get(analysis_project => $analysis_project);
 my $start_cmd = Genome::Model::Build::Command::Start->create(
     models => \@models,
 );
@@ -122,9 +122,9 @@ my $discovery_subject = get_sample_from_subject_mapping($analysis_project, $disc
 my $followup_subject = get_sample_from_subject_mapping($analysis_project, $followup_tag);
 my $germline_subject = get_sample_from_subject_mapping($analysis_project, $germline_tag);
 
-my @models_for_process = Genome::Model::SomaticValidation->get(analysis_projects => [$analysis_project],
+my @models_for_process = Genome::Model::SomaticValidation->get(analysis_project => $analysis_project,
     region_of_interest_set_name => 'SeqCap EZ Human Exome v3.0 + AML RMG pooled probes + WO2830729 pooled probes + WO2840081 pooled probes');
-my @coverage_models_for_process = Genome::Model::SomaticValidation->get(analysis_projects => [$analysis_project],
+my @coverage_models_for_process = Genome::Model::SomaticValidation->get(analysis_project => $analysis_project,
     tumor_sample => [$discovery_subject, $followup_subject]);
 my @germline_models = grep {$_->tumor_sample eq $germline_subject} @models_for_process;
 my $process_command = Genome::VariantReporting::Command::Wrappers::Trio->create(

--- a/bin/cle-test
+++ b/bin/cle-test
@@ -197,7 +197,7 @@ sub diff_build {
         fail(sprintf("Diff command failed to execute for build %s!\n", $build->id));
     }
 
-    if (Library::diff_cmd_has_diffs($diff_cmd)) {
+    if ($diff_cmd->has_diffs()) {
         return $diff_cmd;
     }
     return;
@@ -217,7 +217,7 @@ sub diff_process {
         fail("Diff command failed to execute!\n");
     }
 
-    if (Library::diff_cmd_has_diffs($diff_cmd)) {
+    if ($diff_cmd->has_diffs()) {
         return $diff_cmd;
     }
     return;

--- a/bin/cle-test
+++ b/bin/cle-test
@@ -83,10 +83,19 @@ my $cmd5 = Genome::Config::AnalysisProject::Command::Release->create(
 $cmd5->execute;
 
 my @instrument_data_objects = Genome::InstrumentData->get(id => \@instrument_data);
+my $pre_cqid_model_count = Genome::Model->get();
 my $cmd6 = Genome::Config::Command::ConfigureQueuedInstrumentData->create(
     instrument_data => \@instrument_data_objects,
 );
 $cmd6->execute;
+my $post_cqid_model_count = Genome::Model->get();
+my $expected_number_of_models = 7;
+my $actual_number_of_models = $post_cqid_model_count - $pre_cqid_model_count;
+unless ($actual_number_of_models == $expected_number_of_models) {
+    fail(sprintf("We expected CQID to create %s models and it actually created %s\n",
+        $expected_number_of_models,
+        $actual_number_of_models));
+}
 
 my @models = Genome::Model->get(analysis_projects => [$analysis_project]);
 my $start_cmd = Genome::Model::Build::Command::Start->create(

--- a/bin/cle-test
+++ b/bin/cle-test
@@ -158,14 +158,14 @@ sub get_sample_from_subject_mapping {
 }
 
 sub get_timeout {
-    my $timeout_hours = 14;
+    my $timeout_hours = 24;
     my $timeout_seconds = $timeout_hours * 3600;
 
     return $timeout_seconds;
 }
 
 sub get_process_timeout {
-    my $timeout_hours = 14;
+    my $timeout_hours = 24;
     my $timeout_seconds = $timeout_hours * 3600;
 
     return $timeout_seconds;

--- a/bin/cle-test
+++ b/bin/cle-test
@@ -70,20 +70,9 @@ Genome::Config::AnalysisProject::Command::Release->execute(
 );
 
 my @instrument_data_objects = Genome::InstrumentData->get(id => \@instrument_data);
-my @pre_cqid_models = Genome::Model->get();
-my $pre_cqid_model_count = scalar @pre_cqid_models;
 Genome::Config::Command::ConfigureQueuedInstrumentData->execute(
     instrument_data => \@instrument_data_objects,
 );
-my @post_cqid_models = Genome::Model->get();
-my $post_cqid_model_count = scalar @post_cqid_models;
-my $expected_number_of_models = 7;
-my $actual_number_of_models = $post_cqid_model_count - $pre_cqid_model_count;
-unless ($actual_number_of_models == $expected_number_of_models) {
-    fail(sprintf("We expected CQID to create %s models and it actually created %s\n",
-        $expected_number_of_models,
-        $actual_number_of_models));
-}
 
 my @models = Genome::Model->get(analysis_project => $analysis_project);
 Genome::Model::Build::Command::Start->execute(

--- a/bin/cle-test
+++ b/bin/cle-test
@@ -136,7 +136,8 @@ my $process_command = Genome::VariantReporting::Command::Wrappers::Trio->create(
 );
 my $process = $process_command->execute;
 UR::Context->commit;
-Library::wait_for_process($process);
+
+Library::wait_for_process($process, $timeout);
 
 UR::Context->current->reload($process);
 

--- a/bin/cle-test-wrapper
+++ b/bin/cle-test-wrapper
@@ -1,7 +1,0 @@
-#!/bin/bash
-if test -z "$GENOMECI_BASEDIR"
-then
-    echo "ERROR: must set GENOMECI_BASEDIR" 1>&2
-    exit 1
-fi
-"$GENOMECI_BASEDIR"/bin/model-process-common $1 cle

--- a/bin/cle-test-wrapper
+++ b/bin/cle-test-wrapper
@@ -1,2 +1,7 @@
 #!/bin/bash
+if test -z "$GENOMECI_BASEDIR"
+then
+    echo "ERROR: must set GENOMECI_BASEDIR" 1>&2
+    exit 1
+fi
 "$GENOMECI_BASEDIR"/bin/model-process-common $1 cle

--- a/bin/cle-test-wrapper
+++ b/bin/cle-test-wrapper
@@ -1,3 +1,2 @@
 #!/bin/bash
-#"$GENOMECI_BASEDIR"/bin/model-process-common $1 cle
-/gscuser/aregier/git/genome/fix/jenkins/bin/model-process-common $1 cle
+"$GENOMECI_BASEDIR"/bin/model-process-common $1 cle

--- a/bin/cle-test-wrapper
+++ b/bin/cle-test-wrapper
@@ -1,0 +1,3 @@
+#!/bin/bash
+#"$GENOMECI_BASEDIR"/bin/model-process-common $1 cle
+/gscuser/aregier/git/genome/fix/jenkins/bin/model-process-common $1 cle

--- a/bin/model-process-common
+++ b/bin/model-process-common
@@ -45,6 +45,14 @@ export PERL5LIB="$GENOMECI_BASEDIR/lib:$PERL5LIB"
 if [ "$2" = "process" ]
 then
     "$GENOMECI_BASEDIR"/bin/process-test-multi
-else
+elif [ "$2" = "model" ]
+then
     "$GENOMECI_BASEDIR"/bin/model-test-multi
+elif [ "$2" = "cle" ]
+then
+    #"$GENOMECI_BASEDIR"/bin/cle-test
+    /gscuser/aregier/git/genome/fix/jenkins/bin/cle-test
+else
+    echo "ERROR: must set type of test [model, process, or cle]" 1>&2
+    exit 1
 fi

--- a/bin/model-process-common
+++ b/bin/model-process-common
@@ -50,8 +50,7 @@ then
     "$GENOMECI_BASEDIR"/bin/model-test-multi
 elif [ "$2" = "cle" ]
 then
-    #"$GENOMECI_BASEDIR"/bin/cle-test
-    /gscuser/aregier/git/genome/fix/jenkins/bin/cle-test
+    "$GENOMECI_BASEDIR"/bin/cle-test
 else
     echo "ERROR: must set type of test [model, process, or cle]" 1>&2
     exit 1

--- a/bin/model-test
+++ b/bin/model-test
@@ -1,2 +1,7 @@
 #!/bin/bash
+if test -z "$GENOMECI_BASEDIR"
+then
+    echo "ERROR: must set GENOMECI_BASEDIR" 1>&2
+    exit 1
+fi
 "$GENOMECI_BASEDIR"/bin/model-process-common $1 model

--- a/bin/model-test-multi
+++ b/bin/model-test-multi
@@ -33,7 +33,7 @@ Library::wait_for_build($build, $start_time, get_timeout());
 
 $build = UR::Context->current->reload('Genome::Model::Build', id => $build->id);
 
-check_build_failure($build);
+Library::check_build_failure($build);
 
 diff_build($build);
 
@@ -134,17 +134,6 @@ sub get_initial_build {
     return $build;
 }
 
-sub check_build_failure {
-    my $build = shift;
-
-    if ($build->status eq 'Succeeded') {
-        printf("Build status is %s.\n", $build->status);
-    } else {
-        Library::send_fail_mail();
-        build_view_and_exit($build);
-    }
-}
-
 sub diff_build {
     my $build = shift;
 
@@ -161,14 +150,6 @@ sub diff_build {
         exit(255);
     }
 
-}
-
-sub build_view_and_exit {
-    my $build = shift;
-    my $bv_command = Genome::Model::Build::Command::View->create(
-        build => $build);
-    $bv_command->execute;
-    exit(255);
 }
 
 sub fail {

--- a/bin/model-test-multi
+++ b/bin/model-test-multi
@@ -87,9 +87,7 @@ sub get_timeout {
     );
     my $DEFAULT_TIMEOUT = 18;
     my $timeout_hours = $MODEL_TIMEOUTS{model_subname()} || $DEFAULT_TIMEOUT;
-    my $timeout_seconds = $timeout_hours * 3600;
-
-    return $timeout_seconds;
+    return Library::get_timeout_seconds($timeout_hours);
 }
 
 sub create_build {

--- a/bin/model-test-multi
+++ b/bin/model-test-multi
@@ -145,7 +145,7 @@ sub diff_build {
         fail("Diff command failed to execute!\n");
     }
 
-    if (Library::diff_cmd_has_diffs($diff_cmd)) {
+    if ($diff_cmd->has_diffs()) {
         Library::send_diff_mail($diff_cmd);
         exit(255);
     }

--- a/bin/model-test-multi
+++ b/bin/model-test-multi
@@ -153,13 +153,5 @@ sub diff_build {
 }
 
 sub fail {
-    if (scalar(@_) == 1) {
-        print @_;
-    } elsif (scalar(@_) > 1) {
-        printf @_;
-    } else {
-        print "Failed to execute test model\n";
-    }
-
-    exit(255);
+    Library::fail("test model", @_);
 }

--- a/bin/model-test-multi
+++ b/bin/model-test-multi
@@ -186,8 +186,7 @@ sub diff_build {
         fail("Diff command failed to execute!\n");
     }
 
-    my $has_diffs = (defined($diff_cmd->_diffs) && scalar(keys %{$diff_cmd->_diffs})) || 0;
-    if ($has_diffs) {
+    if (Library::diff_cmd_has_diffs($diff_cmd)) {
         Library::send_diff_mail($diff_cmd);
         exit(255);
     }

--- a/bin/model-test-multi
+++ b/bin/model-test-multi
@@ -28,7 +28,8 @@ if (Genome::Sys->username eq 'apipe-tester' && !$ENV{MODEL_TEST_TO}) {
 }
 
 my $build = get_initial_build();
-wait_for_build($build);
+my $start_time = time;
+Library::wait_for_build($build, $start_time, get_timeout());
 
 $build = UR::Context->current->reload('Genome::Model::Build', id => $build->id);
 
@@ -131,35 +132,6 @@ sub get_initial_build {
         $build = create_build();
     }
     return $build;
-}
-
-sub wait_for_build {
-    my $build = shift;
-
-    my $event = $build->the_master_event;
-    unless ($event) {
-        fail("Could not get the build's master event!\n");
-    }
-
-    my $timeout = get_timeout();
-    printf("Monitoring build (%s) until it completes or timeout "
-        . "of %s minutes is reached.\n\n", $build->id, $timeout / 60);
-
-    my $start_time = time;
-    while (!grep { $event->event_status eq $_ } ('Succeeded',
-            'Failed', 'Crashed')) {
-        UR::Context->current->reload($event);
-
-        my $elapsed_time = time - $start_time;
-        if ($elapsed_time > $timeout) {
-            printf("Build (%s) timed out after %s minutes",
-                $build->id, $timeout / 60);
-            Library::send_timeout_mail();
-            build_view_and_exit($build);
-        }
-
-        sleep(30);
-    }
 }
 
 sub check_build_failure {

--- a/bin/process-test
+++ b/bin/process-test
@@ -1,2 +1,7 @@
 #!/bin/bash
+if test -z "$GENOMECI_BASEDIR"
+then
+    echo "ERROR: must set GENOMECI_BASEDIR" 1>&2
+    exit 1
+fi
 "$GENOMECI_BASEDIR"/bin/model-process-common $1 process

--- a/bin/process-test-multi
+++ b/bin/process-test-multi
@@ -25,13 +25,10 @@ check_process_failure($process);
 
 diff_process($process);
 
-
 # functions
 sub get_timeout {
     my $DEFAULT_TIMEOUT = 6;
-    my $timeout_seconds = $DEFAULT_TIMEOUT * 3600;
-
-    return $timeout_seconds;
+    return Library::get_timeout_seconds($DEFAULT_TIMEOUT);
 }
 
 sub get_initial_process {

--- a/bin/process-test-multi
+++ b/bin/process-test-multi
@@ -10,18 +10,17 @@ use Genome::Process::Test::IntegrationTests;
 use strict;
 use warnings;
 
-
 # flush output buffer after every write or print
 local $| = 1;
 Library::setup_model_process_test();
 Library::set_genome_software_result_test_name();
 
 my $process = get_initial_process();
-wait_for_process($process);
+Library::wait_for_process($process);
 
 UR::Context->current->reload($process);
 
-check_process_failure($process);
+Library::check_process_failure($process);
 
 diff_process($process);
 
@@ -68,40 +67,6 @@ sub process_name {
     return 'trio_main';
 }
 
-sub wait_for_process {
-    my $process = shift;
-
-    my $timeout = get_timeout();
-    printf("Monitoring process (%s) until it completes or timeout "
-        . "of %s minutes is reached.\n\n", $process->id, $timeout / 60);
-
-    my $start_time = time;
-    while (!grep { $process->status eq $_ } ('Succeeded', 'Crashed')) {
-        UR::Context->current->reload($process);
-
-        my $elapsed_time = time - $start_time;
-        if ($elapsed_time > $timeout) {
-            printf("Process (%s) timed out after %s minutes",
-                $process->id, $timeout / 60);
-            Library::send_timeout_mail();
-            process_view_and_exit($process);
-        }
-
-        sleep(30);
-    }
-}
-
-sub check_process_failure {
-    my $process = shift;
-
-    if ($process->status eq 'Succeeded') {
-        printf("Build status is %s.\n", $process->status);
-    } else {
-        Library::send_fail_mail();
-        process_view_and_exit($process);
-    }
-}
-
 sub diff_process {
     my $process = shift;
 
@@ -119,14 +84,6 @@ sub diff_process {
         exit(255);
     }
 
-}
-
-sub process_view_and_exit {
-    my $process = shift;
-    my $pv_command = Genome::Process::Command::View->create(
-        process => $process);
-    $pv_command->execute;
-    exit(255);
 }
 
 sub fail {

--- a/bin/process-test-multi
+++ b/bin/process-test-multi
@@ -16,7 +16,7 @@ Library::setup_model_process_test();
 Library::set_genome_software_result_test_name();
 
 my $process = get_initial_process();
-Library::wait_for_process($process);
+Library::wait_for_process($process, get_timeout());
 
 UR::Context->current->reload($process);
 

--- a/bin/process-test-multi
+++ b/bin/process-test-multi
@@ -117,8 +117,7 @@ sub diff_process {
         fail("Diff command failed to execute!\n");
     }
 
-    my $has_diffs = (defined($diff_cmd->_diffs) && scalar(keys %{$diff_cmd->_diffs})) || 0;
-    if ($has_diffs) {
+    if (Library::diff_cmd_has_diffs($diff_cmd)) {
         Library::send_diff_mail($diff_cmd);
         exit(255);
     }

--- a/bin/process-test-multi
+++ b/bin/process-test-multi
@@ -79,7 +79,7 @@ sub diff_process {
         fail("Diff command failed to execute!\n");
     }
 
-    if (Library::diff_cmd_has_diffs($diff_cmd)) {
+    if ($diff_cmd->has_diffs()) {
         Library::send_diff_mail($diff_cmd);
         exit(255);
     }

--- a/bin/process-test-multi
+++ b/bin/process-test-multi
@@ -87,13 +87,5 @@ sub diff_process {
 }
 
 sub fail {
-    if (scalar(@_) == 1) {
-        print @_;
-    } elsif (scalar(@_) > 1) {
-        printf @_;
-    } else {
-        print "Failed to execute test process\n";
-    }
-
-    exit(255);
+    Library::fail("test process", @_);
 }

--- a/lib/Library.pm
+++ b/lib/Library.pm
@@ -266,4 +266,16 @@ sub build_view_and_exit {
     exit(255);
 }
 
+sub fail {
+    my $test_name = shift;
+    if (scalar(@_) == 1) {
+        print @_;
+    } elsif (scalar(@_) > 1) {
+        printf @_;
+    } else {
+        print "Failed to execute $test_name\n";
+    }
+
+    exit(255);
+}
 1;

--- a/lib/Library.pm
+++ b/lib/Library.pm
@@ -173,7 +173,7 @@ sub setup_model_process_test {
 
 sub diff_cmd_has_diffs {
     my $diff_cmd = shift;
-    return $diff_cmd->has_diffs;
+    return (defined($diff_cmd->_diffs) && scalar(keys %{$diff_cmd->_diffs})) || 0;
 }
 
 sub wait_for_build {

--- a/lib/Library.pm
+++ b/lib/Library.pm
@@ -173,7 +173,7 @@ sub setup_model_process_test {
 
 sub diff_cmd_has_diffs {
     my $diff_cmd = shift;
-    return (defined($diff_cmd->_diffs) && scalar(keys %{$diff_cmd->_diffs})) || 0;
+    return $diff_cmd->has_diffs;
 }
 
 sub wait_for_build {

--- a/lib/Library.pm
+++ b/lib/Library.pm
@@ -171,11 +171,6 @@ sub setup_model_process_test {
 
 }
 
-sub diff_cmd_has_diffs {
-    my $diff_cmd = shift;
-    return (defined($diff_cmd->_diffs) && scalar(keys %{$diff_cmd->_diffs})) || 0;
-}
-
 sub wait_for_build {
     my $build = shift;
     my $start_time = shift;

--- a/lib/Library.pm
+++ b/lib/Library.pm
@@ -46,13 +46,15 @@ sub send_fail_mail {
 }
 
 sub send_diff_mail {
-    my $diff_cmd = shift;
+    my @diff_cmds = @_;
 
+    my @bless_messages = map {$_->bless_message} @diff_cmds;
+    my @diffs_messages = map {$_->diff_message} @diff_cmds;
     send_mail_with_topic('Diffs Found',
         '********************************************************************************',
-        $diff_cmd->bless_message,
+        @bless_messages,
         '********************************************************************************',
-        $diff_cmd->diffs_message);
+        @diffs_messages);
 }
 
 sub send_mail_with_topic {

--- a/lib/Library.pm
+++ b/lib/Library.pm
@@ -195,7 +195,7 @@ sub wait_for_build {
         UR::Context->current->reload($build);
         my $elapsed_time = time - $start_time;
         if ($elapsed_time > $timeout) {
-            printf("Build (%s) timed out after %s minutes",
+            printf("Build (%s) timed out after %s minutes\n",
                 $build->id, $timeout / 60);
             Library::send_timeout_mail();
             Library::build_view_and_exit($build);
@@ -229,7 +229,7 @@ sub wait_for_process {
 
         my $elapsed_time = time - $start_time;
         if ($elapsed_time > $timeout) {
-            printf("Process (%s) timed out after %s minutes",
+            printf("Process (%s) timed out after %s minutes\n",
                 $process->id, $timeout / 60);
             Library::send_timeout_mail();
             process_view_and_exit($process);

--- a/lib/Library.pm
+++ b/lib/Library.pm
@@ -166,4 +166,9 @@ sub setup_model_process_test {
 
 }
 
+sub diff_cmd_has_diffs {
+    my $diff_cmd = shift;
+    return (defined($diff_cmd->_diffs) && scalar(keys %{$diff_cmd->_diffs})) || 0;
+}
+
 1;

--- a/lib/Library.pm
+++ b/lib/Library.pm
@@ -37,6 +37,11 @@ sub test_version {
     return $prefix . Revision->test_version();
 }
 
+sub get_timeout_seconds {
+    my $hours = shift;
+    return $hours * 3600;
+}
+
 sub send_timeout_mail {
     send_mail_with_topic('Timed Out');
 }

--- a/lib/Library.pm
+++ b/lib/Library.pm
@@ -218,8 +218,8 @@ sub check_build_failure {
 
 sub wait_for_process {
     my $process = shift;
+    my $timeout = shift;
 
-    my $timeout = get_timeout();
     printf("Monitoring process (%s) until it completes or timeout "
         . "of %s minutes is reached.\n\n", $process->id, $timeout / 60);
 

--- a/lib/Users.pm
+++ b/lib/Users.pm
@@ -59,6 +59,12 @@ sub apipe {
     );
 }
 
+sub cle {
+    return qw(
+        dlarson
+    );
+}
+
 sub reference_alignment {
     return qw(
         fdu


### PR DESCRIPTION
For CLE, we are adding a full regression test that encompasses as much of the bioinformatics protocol as possible, and using real data that has been validated.  It creates an analysis project, creates the models based on the config, runs the builds, and then runs the trio process.  It also diffs the builds and process based on 'blessed' versions.
The jenkins project is here: https://apipe-ci.gsc.wustl.edu/job/CLE_Regression_Test/
(I would also appreciate review of its configuration)
This test is intended to run after a production snapshot is made.  I have attempted to set this up using a parameterized trigger from the Snapshot project - not sure yet if it works.
Once it runs successfully, it should trigger a CLE snapshot.  I haven't yet set this up in jenkins.
We anticipate this test will take on the order of 2 days to run.