### PR TITLE
Fix blessed build matching

### DIFF
--- a/bin/cle-test
+++ b/bin/cle-test
@@ -145,7 +145,7 @@ sub diff_build {
         if ($build->tumor_sample eq $blessed_build->tumor_sample and
                 ((!defined($build->normal_sample) and !defined($blessed_build->normal_sample)) or
                     ($build->normal_sample eq $blessed_build->normal_sample)) and
-            $build->target_region_set_name eq $blessed_build->target_region_set_name) {
+            $build->region_of_interest_set_name eq $blessed_build->region_of_interest_set_name) {
                 $matching_blessed_build = $blessed_build;
                 last;
             }


### PR DESCRIPTION
We had a typo where we were checking the target_region_set_name between a blessed build and a test build to determine if they should be compared. It should have been checking region_of_interest_set_name as this is the feature-list that is actually varied to get different coverages.
