### PR TITLE
Eliminate undefined value in eq warning

### DIFF
--- a/bin/cle-test
+++ b/bin/cle-test
@@ -144,7 +144,8 @@ sub diff_build {
     for my $blessed_build (@blessed_builds) {
         if ($build->tumor_sample eq $blessed_build->tumor_sample and
                 ((!defined($build->normal_sample) and !defined($blessed_build->normal_sample)) or
-                    ($build->normal_sample eq $blessed_build->normal_sample)) and
+                    (defined($build->normal_sample) and defined($blessed_build->normal_sample) and
+                        $build->normal_sample eq $blessed_build->normal_sample)) and
             $build->region_of_interest_set_name eq $blessed_build->region_of_interest_set_name) {
                 $matching_blessed_build = $blessed_build;
                 last;

--- a/bin/cle-test
+++ b/bin/cle-test
@@ -146,7 +146,7 @@ sub diff_build {
                 ((!defined($build->normal_sample) and !defined($blessed_build->normal_sample)) or
                     (defined($build->normal_sample) and defined($blessed_build->normal_sample) and
                         $build->normal_sample eq $blessed_build->normal_sample)) and
-            $build->region_of_interest_set_name eq $blessed_build->region_of_interest_set_name) {
+            $build->region_of_interest_set->name eq $blessed_build->region_of_interest_set->name) {
                 $matching_blessed_build = $blessed_build;
                 last;
             }


### PR DESCRIPTION
If either the build or blessed build's normal sample isn't defined,
we don't want to match them.