### PR TITLE
Remove 'bless_message' from e-mail

### DIFF
--- a/lib/Library.pm
+++ b/lib/Library.pm
@@ -53,7 +53,7 @@ sub send_fail_mail {
 sub send_diff_mail {
     my @diff_cmds = @_;
 
-    my @diffs_messages = map {$_->diff_message} @diff_cmds;
+    my @diffs_messages = map {$_->diffs_message} @diff_cmds;
     send_mail_with_topic('Diffs Found',
         '********************************************************************************',
         @diffs_messages);

--- a/lib/Library.pm
+++ b/lib/Library.pm
@@ -53,11 +53,8 @@ sub send_fail_mail {
 sub send_diff_mail {
     my @diff_cmds = @_;
 
-    my @bless_messages = map {$_->bless_message} @diff_cmds;
     my @diffs_messages = map {$_->diff_message} @diff_cmds;
     send_mail_with_topic('Diffs Found',
-        '********************************************************************************',
-        @bless_messages,
         '********************************************************************************',
         @diffs_messages);
 }


### PR DESCRIPTION
For DiffBlessed commands, this message is already included
in the diff_message.  For non-DiffBlessed Diff commands,
bless_message is not defined