### PR TITLE
Model Summaries: moved to jenkins apipe-pi

### DIFF
--- a/bin/model-summary-failed
+++ b/bin/model-summary-failed
@@ -1,3 +1,0 @@
-#!/bin/bash -l
-
-bsub -Is -q apipe-ci genome model admin model-summary --auto --hide-statuses Running,Scheduled,Requested 'builds.status=Failed,builds.run_by=apipe-builder,subclass_name!=Genome::Model::ImportedReferenceSequence'

--- a/bin/model-summary-unstartable
+++ b/bin/model-summary-unstartable
@@ -1,3 +1,0 @@
-#!/bin/bash -l
-
-bsub -Is -q apipe-ci genome model admin model-summary --auto --hide-statuses Running,Scheduled,Requested 'builds.status=Unstartable,builds.run_by=apipe-builder,subclass_name!=Genome::Model::ImportedReferenceSequence'


### PR DESCRIPTION
These 2 scripts were called from jenkins and just submit the model summary command to LSF. This has been moved to apipe-pi