### PR TITLE
Move dmorton out of active user list.

### DIFF
--- a/lib/Users.pm
+++ b/lib/Users.pm
@@ -13,6 +13,7 @@ sub apipe_ignore {
         ccarey
         cfederer
         coliver
+        dmorton
         eclark
         edemello
         ehvatum
@@ -48,7 +49,6 @@ sub apipe {
         abrummet
         acoffman
         aregier
-        dmorton
         ebelter
         fdu
         jmcmicha


### PR DESCRIPTION
We're not using this list to send notifications as much anymore (thanks to tests running on PRs), but this updates it.